### PR TITLE
Fix reset of layout when changing breakpoints.

### DIFF
--- a/src/utils/ResponsiveUtils.js
+++ b/src/utils/ResponsiveUtils.js
@@ -58,36 +58,19 @@ export function findOrGenerateResponsiveLayout(
 
     const max = Math.max(...layoutsLength);
 
-    if (max !== breakpoint) {
-        for (let i = 0, len = breakpointsSorted.length; i < len; i++) {
-            const b = breakpointsSorted[i];
-            if (layouts[b]) {
-                if (layouts[b].length === max) {
-                    if (layouts[b] === breakpoint) {
-                        break;
-                    } else {
-                        breakpoint = b;
-                    }
-                }
-            }
-        }
-    } else {
-        return cloneLayout(layouts[breakpoint])
-    }
-
     if (max !== lastBreakpointLength) {
-        for (let i = 0, len = breakpointsSorted.length; i < len; i++) {
-            const b = breakpointsSorted[i];
-            if (layouts[b]) {
-                if (layouts[b].length === max) {
-                    if (layouts[b] === lastBreakpoint) {
-                        break;
-                    } else {
-                        lastBreakpoint = b;
-                    }
-                }
+      for (let i = 0, len = breakpointsSorted.length; i < len; i++) {
+        const b = breakpointsSorted[i];
+        if (layouts[b]) {
+          if (layouts[b].length === max) {
+            if (b === lastBreakpoint) {
+              break;
+            } else {
+              lastBreakpoint = b;
             }
+          }
         }
+      }
     }
 
     // Find or generate the next layout


### PR DESCRIPTION
It seemed like the grid would sometimes reset the layout for the breakpoint when changing browser width. This code somewhat resolves that problem.

It would probably be good to try to merge the existing coordinates and sizes that have already been set with new additions that do not yet exist in the layout for the new breakpoint.